### PR TITLE
GitHub Actions Workflow file to deploy to Prod

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,59 @@
+name: Deploy to prod by SSH'ing to a host and running make prod
+
+on:
+  push:
+    branches:
+      - main # should be ${{ secrets.PRODUCTION_BRANCH }}
+
+jobs:
+  # Expects the host to have this
+  #  - ssh-keyscan
+  #  - git
+  #  - make
+  #  - dig
+  #  - rm
+  #  - grep
+  #  - install
+  #  - sed (GNU version)
+  #  - bash (as default shell for the ssh user)
+  # On ubuntu, this might require installing the following apt packages:
+  #  - dnsutils (dig)
+  #  - openssh-client (ssh-keyscan)
+  #  - make
+  #  - git
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Write SSH keys
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_ed25519
+          printf '%s' '${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}' > ~/.ssh/id_ed25519
+          host='${{ secrets.PRODUCTION_SSH_HOST }}'
+          hosts="$(dig +short "$host" | grep -v '\.$' | sed -z 's|\n|,|g')$host"
+          ssh-keyscan -H -p ${{ secrets.PRODUCTION_SSH_PORT }} "$hosts" > ~/.ssh/known_hosts
+
+      - name: Connect, Pull, Make
+        # the GH_ACTIONS_PRODUCTION no-op is just so you can find the process easily on the host
+        run: |
+          ssh \
+            -o IdentitiesOnly=yes                                                                    \
+            -i ~/.ssh/id_ed25519                                                                     \
+            -o UserKnownHostsFile=~/.ssh/known_hosts                                                 \
+            -T                                                                                       \
+            -p ${{ secrets.PRODUCTION_SSH_PORT }}                                                    \
+            ${{ secrets.PRODUCTION_SSH_USER }}@${{ secrets.PRODUCTION_SSH_HOST }}                    \
+            ": GH_ACTIONS_PRODUCTION ;                                                               \
+             set -Eeuxo pipefail ;                                                                   \
+             cd ${{ secrets.PRODUCTION_WORK_DIR }} ;                                                 \
+             git stash -u ;                                                                          \
+             git checkout ${{ secrets.PRODUCTION_BRANCH }} ;                                         \
+             git pull --rebase --force ${{ secrets.REMOTE_NAME }} ${{ secrets.PRODUCTION_BRANCH }} ; \
+             make clean ;                                                                            \
+             make prod ;                                                                             \
+             exit 0"
+
+      - name: Cleanup
+        run: rm -rf ~/.ssh

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -29,10 +29,10 @@ jobs:
 
       - name: Write SSH keys
         run: |
-          install -m 600 -D /dev/null ~/.ssh/id_ed25519
+          install --mode=600 -D /dev/null ~/.ssh/id_ed25519
           printf '%s' '${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}' > ~/.ssh/id_ed25519
           host='${{ secrets.PRODUCTION_SSH_HOST }}'
-          hosts="$(dig +short "$host" | grep -v '\.$' | sed -z 's|\n|,|g')$host"
+          hosts="$(dig +short "$host" | grep --invert-match '\.$' | sed --null-data 's|\n|,|g')$host"
           ssh-keyscan -H -p ${{ secrets.PRODUCTION_SSH_PORT }} "$hosts" > ~/.ssh/known_hosts
 
       - name: Connect, Pull, Make
@@ -48,11 +48,11 @@ jobs:
             ": GH_ACTIONS_PRODUCTION ;                                                               \
              set -Eeuxo pipefail ;                                                                   \
              cd ${{ secrets.PRODUCTION_WORK_DIR }} ;                                                 \
-             git stash -u ;                                                                          \
-             git checkout ${{ secrets.PRODUCTION_BRANCH }} ;                                         \
+             git stash --include-untracked ;                                                         \
+             git checkout --force ${{ secrets.PRODUCTION_BRANCH }} ;                                         \
              git pull --rebase --force ${{ secrets.REMOTE_NAME }} ${{ secrets.PRODUCTION_BRANCH }} ; \
              make clean ;                                                                            \
              make prod"
 
       - name: Cleanup
-        run: rm -rf ~/.ssh
+        run: rm --recursive --force ~/.ssh

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -52,8 +52,7 @@ jobs:
              git checkout ${{ secrets.PRODUCTION_BRANCH }} ;                                         \
              git pull --rebase --force ${{ secrets.REMOTE_NAME }} ${{ secrets.PRODUCTION_BRANCH }} ; \
              make clean ;                                                                            \
-             make prod ;                                                                             \
-             exit 0"
+             make prod"
 
       - name: Cleanup
         run: rm -rf ~/.ssh


### PR DESCRIPTION
FYI: ga == GitHub Actions
Please Merge #9 first, then look at the diff of this PR

Add a GitHub Actions Workflow ([.github/workflows/deploy-production.yaml](https://github.com/cubernetes/ft-transcendence/blob/feature/ga-deploy-prod/.github/workflows/deploy-production.yaml)) that does the following:
1. Use the 'Repository Secrets' to set up an environment that can ssh into a configured remote server/host (for instance: Repo Settings -> Secrets and variables -> Actions -> Repository Secrets -> PRODUCTION_SSH_PRIVATE_KEY. You probably can't even access the settings tho)
2. SSH into the configured host with a configured user and cd into a configured directory (where the repo resides)
3. stash all (even untracked) files to make the checkout work
4. Force checkout
5. Force pull
6. make clean
7. make prod (start docker compose project)

Bam, project deployed and up and running, if nothing failed.