### PR TITLE
Makefile target for local TLS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 
 # This file should only contains secrets. Makes continuous deployment easier
 
-JWT_SECRET='changeme'
+JWT_SECRET=changeme

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Important: Never put quotes anywhere: https://github.com/docker/cli/issues/3630
+
 # This file should only contains secrets. Makes continuous deployment easier
 
 JWT_SECRET='changeme'

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ check-env:
 dev: check-env
 	[ -n "$(DEV_HTTP_PORT)" ] && \
 	[ -n "$(DEV_HTTPS_PORT)" ] && \
-	[ -n "$(DEV_DOMAINS)" ] && \
+	[ -n "$(DEV_SITES)" ] && \
 	HTTP_PORT=$(DEV_HTTP_PORT) \
 	HTTPS_PORT=$(DEV_HTTPS_PORT) \
-	DOMAINS=$(DEV_DOMAINS) \
+	SITES=$(DEV_SITES) \
 	$(DC) up -d --build
 
 .PHONY: prod
 prod: check-env
 	[ -n "$(PROD_HTTP_PORT)" ] && \
 	[ -n "$(PROD_HTTPS_PORT)" ] && \
-	[ -n "$(PROD_DOMAINS)" ] && \
+	[ -n "$(PROD_SITES)" ] && \
 	HTTP_PORT=$(PROD_HTTP_PORT) \
 	HTTPS_PORT=$(PROD_HTTPS_PORT) \
-	DOMAINS=$(PROD_DOMAINS) \
+	SITES=$(PROD_SITES) \
 	$(DC) up -d --build
 
 .PHONY: down

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,15 @@ dev-tls: check-env
 	SITES="$$(printf %s "$(DEV_SITES)" | sed 's/http\(:\/\/[^[:space:]]*\) /http\1 https\1 /g')" \
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
 	$(DC) up -d --build
+	# Explanation of the SITES variable:
+	# - $(DEV_SITES) is a space-separated list of sites (i.e. "http://localhost https://whatever http://127.0.0.1")
+	# - then we're printing that string and pipe it through sed to do some transormation of that strings
+	# - namely, what we want is do turn every http sites into a https site (for tls), BUT ALSO keep the old http site
+	# - Therefore, the example string from above would turn into this:
+	# - "http://localhost https://localhost https://whatever http://127.0.0.1 https://127.0.0.1"
+	# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
+	# - The sed command matches for sites by search for this pattern: 'http\(:\/\/[^[:space:]]*\) '
+	# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
 
 .PHONY: prod
 prod: check-env

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ dev-tls: check-env
 	# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
 	# - The sed command matches for sites by search for this pattern: 'http\(:\/\/[^[:space:]]*\) '
 	# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
+	# Explanation of the CADDY_EXTRA_GLOBAL_DIRECTIVES variable:
+	# - This one is merely to add extra directives to caddy. The reason to put it inside a printf call is to allow
+	#   for multiple lines (== multiple directives). The 'auto_https disable_redirects' directive is to disable
+	#   automatic redirect from http to https
 
 .PHONY: prod
 prod: check-env

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ dev: check-env
 	[ -n "$(DEV_HTTP_PORT)" ] && \
 	[ -n "$(DEV_HTTPS_PORT)" ] && \
 	[ -n "$(DEV_SITES)" ] && \
-	HTTP_PORT=$(DEV_HTTP_PORT) \
-	HTTPS_PORT=$(DEV_HTTPS_PORT) \
-	SITES=$(DEV_SITES) \
+	HTTP_PORT="$(DEV_HTTP_PORT)" \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	SITES="$(DEV_SITES)" \
 	$(DC) up -d --build
 
 .PHONY: prod
@@ -26,9 +26,9 @@ prod: check-env
 	[ -n "$(PROD_HTTP_PORT)" ] && \
 	[ -n "$(PROD_HTTPS_PORT)" ] && \
 	[ -n "$(PROD_SITES)" ] && \
-	HTTP_PORT=$(PROD_HTTP_PORT) \
-	HTTPS_PORT=$(PROD_HTTPS_PORT) \
-	SITES=$(PROD_SITES) \
+	HTTP_PORT="$(PROD_HTTP_PORT)" \
+	HTTPS_PORT="$(PROD_HTTPS_PORT)" \
+	SITES="$(PROD_SITES)" \
 	$(DC) up -d --build
 
 .PHONY: down

--- a/Makefile
+++ b/Makefile
@@ -30,22 +30,27 @@ dev-tls: check-env
 	[ -n "$(DEV_SITES)" ] && \
 	HTTP_PORT="$(DEV_HTTP_PORT)" \
 	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
-	SITES="$$(printf %s "$(DEV_SITES)" | sed 's/http\(:\/\/[^[:space:]]*\) /http\1 https\1 /g')" \
+	SITES="$$(printf %s "$(DEV_SITES)" | sed 's/http\(:\/\/[^[:space:]]*\)\( \|$$\)/http\1 https\1 /g')" \
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf 'tls internal')" \
 	$(DC) up -d --build
-	# Explanation of the SITES variable:
-	# - $(DEV_SITES) is a space-separated list of sites (i.e. "http://localhost https://whatever http://127.0.0.1")
-	# - then we're printing that string and pipe it through sed to do some transormation of that strings
-	# - namely, what we want is do turn every http site into a https site (for tls), BUT ALSO keep the old http site
-	# - Therefore, the example string from above would turn into this:
-	# - "http://localhost https://localhost https://whatever http://127.0.0.1 https://127.0.0.1"
-	# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
-	# - The sed command matches for sites by searching for this pattern: 'http\(:\/\/[^[:space:]]*\) '
-	# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
-	# Explanation of the CADDY_EXTRA_GLOBAL_DIRECTIVES variable:
-	# - This one is merely to add extra directives to caddy. The reason to put it inside a printf call is to allow
-	#   for multiple lines (== multiple directives). The 'auto_https disable_redirects' directive is to disable
-	#   automatic redirect from http to https
+	@# Explanation of the SITES variable:
+	@# - $(DEV_SITES) is a space-separated list of sites (i.e. "http://localhost https://whatever http://127.0.0.1")
+	@# - then we're printing that string and pipe it through sed to do some transormation of that strings
+	@# - namely, what we want is do turn every http site into a https site (for tls), BUT ALSO keep the old http site
+	@# - Therefore, the example string from above would turn into this:
+	@# - "http://localhost https://localhost https://whatever http://127.0.0.1 https://127.0.0.1"
+	@# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
+	@# - The sed command matches for sites by searching for this pattern: 'http\(:\/\/[^[:space:]]*\) '
+	@# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
+	@# Explanation of the CADDY_EXTRA_GLOBAL_DIRECTIVES variable:
+	@# - This one is merely to add extra directives to caddy. The reason to put it inside a printf call is to allow
+	@#   for multiple lines (== multiple directives). The 'auto_https disable_redirects' directive is to disable
+	@#   automatic redirect from http to https
+	@# Explanation of the CADDY_EXTRA_SITE_DIRECTIVES variable:
+	@# - Similar to the other CADDY... variable, this one is to add directives to the main site block in the Caddyfile
+	@#   which is needed because especially for local development we want to use self-signed certificates and therefore
+	@#   need to specify the 'tls internal' option
 
 .PHONY: prod
 prod: check-env

--- a/Makefile
+++ b/Makefile
@@ -19,22 +19,9 @@ dev: check-env
 	HTTP_PORT="$(DEV_HTTP_PORT)" \
 	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
 	SITES="$(DEV_SITES)" \
-	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
-	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf 'tls internal')" \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="auto_https disable_redirects" \
+	CADDY_EXTRA_SITE_DIRECTIVES="tls internal" \
 	$(DC) up -d --build
-
-.PHONY: dev
-dev-tls: check-env
-	[ -n "$(DEV_HTTP_PORT)" ] && \
-	[ -n "$(DEV_HTTPS_PORT)" ] && \
-	[ -n "$(DEV_SITES)" ] && \
-	HTTP_PORT="$(DEV_HTTP_PORT)" \
-	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
-	SITES="$$(printf %s "$(DEV_SITES)" | sed 's/http\(:\/\/[^[:space:]]*\)\( \|$$\)/http\1 https\1 /g')" \
-	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
-	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf 'tls internal')" \
-	$(DC) up -d --build
-	@# See wiki for explanation of the commands: https://github.com/cubernetes/ft-transcendence/wiki/Makefile-dev%E2%80%90tls-target-explanation
 
 .PHONY: prod
 prod: check-env

--- a/Makefile
+++ b/Makefile
@@ -34,23 +34,7 @@ dev-tls: check-env
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
 	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf 'tls internal')" \
 	$(DC) up -d --build
-	@# Explanation of the SITES variable:
-	@# - $(DEV_SITES) is a space-separated list of sites (i.e. "http://localhost https://whatever http://127.0.0.1")
-	@# - then we're printing that string and pipe it through sed to do some transormation of that strings
-	@# - namely, what we want is do turn every http site into a https site (for tls), BUT ALSO keep the old http site
-	@# - Therefore, the example string from above would turn into this:
-	@# - "http://localhost https://localhost https://whatever http://127.0.0.1 https://127.0.0.1"
-	@# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
-	@# - The sed command matches for sites by searching for this pattern: 'http\(:\/\/[^[:space:]]*\) '
-	@# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
-	@# Explanation of the CADDY_EXTRA_GLOBAL_DIRECTIVES variable:
-	@# - This one is merely to add extra directives to caddy. The reason to put it inside a printf call is to allow
-	@#   for multiple lines (== multiple directives). The 'auto_https disable_redirects' directive is to disable
-	@#   automatic redirect from http to https
-	@# Explanation of the CADDY_EXTRA_SITE_DIRECTIVES variable:
-	@# - Similar to the other CADDY... variable, this one is to add directives to the main site block in the Caddyfile
-	@#   which is needed because especially for local development we want to use self-signed certificates and therefore
-	@#   need to specify the 'tls internal' option
+	@# See wiki for explanation of the commands: https://github.com/cubernetes/ft-transcendence/wiki/Makefile-dev%E2%80%90tls-target-explanation
 
 .PHONY: prod
 prod: check-env

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ dev: check-env
 	HTTP_PORT="$(DEV_HTTP_PORT)" \
 	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
 	SITES="$(DEV_SITES)" \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf 'tls internal')" \
 	$(DC) up -d --build
 
 .PHONY: dev

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ check-env:
 dev: check-env
 	[ -n "$(DEV_HTTP_PORT)" ] && \
 	[ -n "$(DEV_HTTPS_PORT)" ] && \
-	[ -n "$(DEV_SITES)" ] && \
+	[ -n "$(DEV_DOMAINS)" ] && \
 	HTTP_PORT="$(DEV_HTTP_PORT)" \
 	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
-	SITES="$(DEV_SITES)" \
+	DOMAINS="$(DEV_DOMAINS)" \
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="auto_https disable_redirects" \
 	CADDY_EXTRA_SITE_DIRECTIVES="tls internal" \
 	$(DC) up -d --build
@@ -27,10 +27,10 @@ dev: check-env
 prod: check-env
 	[ -n "$(PROD_HTTP_PORT)" ] && \
 	[ -n "$(PROD_HTTPS_PORT)" ] && \
-	[ -n "$(PROD_SITES)" ] && \
+	[ -n "$(PROD_DOMAINS)" ] && \
 	HTTP_PORT="$(PROD_HTTP_PORT)" \
 	HTTPS_PORT="$(PROD_HTTPS_PORT)" \
-	SITES="$(PROD_SITES)" \
+	DOMAINS="$(PROD_DOMAINS)" \
 	$(DC) up -d --build
 
 .PHONY: down

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ dev: check-env
 	SITES="$(DEV_SITES)" \
 	$(DC) up -d --build
 
+.PHONY: dev
+dev-tls: check-env
+	[ -n "$(DEV_HTTP_PORT)" ] && \
+	[ -n "$(DEV_HTTPS_PORT)" ] && \
+	[ -n "$(DEV_SITES)" ] && \
+	HTTP_PORT="$(DEV_HTTP_PORT)" \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	SITES="$$(printf %s "$(DEV_SITES)" | sed 's/http\(:\/\/[^[:space:]]*\) /http\1 https\1 /g')" \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf 'auto_https disable_redirects')" \
+	$(DC) up -d --build
+
 .PHONY: prod
 prod: check-env
 	[ -n "$(PROD_HTTP_PORT)" ] && \

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ dev-tls: check-env
 	# Explanation of the SITES variable:
 	# - $(DEV_SITES) is a space-separated list of sites (i.e. "http://localhost https://whatever http://127.0.0.1")
 	# - then we're printing that string and pipe it through sed to do some transormation of that strings
-	# - namely, what we want is do turn every http sites into a https site (for tls), BUT ALSO keep the old http site
+	# - namely, what we want is do turn every http site into a https site (for tls), BUT ALSO keep the old http site
 	# - Therefore, the example string from above would turn into this:
 	# - "http://localhost https://localhost https://whatever http://127.0.0.1 https://127.0.0.1"
 	# - note that both http sites got turned into https sites, but the one https site that was already there was not downgraded to http, this is intentional
-	# - The sed command matches for sites by search for this pattern: 'http\(:\/\/[^[:space:]]*\) '
+	# - The sed command matches for sites by searching for this pattern: 'http\(:\/\/[^[:space:]]*\) '
 	# - That pattern captures the part after the http. In the replacement, it then uses the capture twice to generate the http and also the https site.
 	# Explanation of the CADDY_EXTRA_GLOBAL_DIRECTIVES variable:
 	# - This one is merely to add extra directives to caddy. The reason to put it inside a printf call is to allow

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,23 @@ D := docker
 
 .DEFAULT_GOAL := dev
 
-include .env
+-include .env
 include config.env
 .EXPORT_ALL_VARIABLES:
 
 .PHONY: check-env
 check-env:
-	@test -f .env || cp .env.example .env
+	@test -e .env || { \
+		printf '\033[33m%s \033[42;30m%s\033[m\033[33m\n%s\n%s\n%s\n%s\n%s\033[m' \
+			"Warning: .env doesn't exist, trying to run" "cp .env.example .env" \
+			"Warning: Since the file didn't exist, no environment variables from" \
+			"Warning: that file will be included/exposed inside this Makefile." \
+			"Warning: It is STRONGLY recommended you abort this step, manually" \
+			"Warning: copy the file, adjust its contents, and then run make again." \
+			"Warning: Press ENTER to continue (run the cp command) or CTRL-C to abort..."; \
+		read c; \
+		cp .env.example .env; \
+	}
 
 .PHONY: dev
 dev: check-env

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
         volumes:
             - "caddy_data:/srv/.local/share/caddy/"
         environment:
-            - SITES=${SITES:-http://localhost}
+            - SITES=${SITES:-localhost}
             - CADDY_EXTRA_GLOBAL_DIRECTIVES=${CADDY_EXTRA_GLOBAL_DIRECTIVES:-}
             - CADDY_EXTRA_SITE_DIRECTIVES=${CADDY_EXTRA_SITE_DIRECTIVES:-}
         develop:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,7 @@ services:
         environment:
             - SITES=${SITES:-http://localhost}
             - CADDY_EXTRA_GLOBAL_DIRECTIVES=${CADDY_EXTRA_GLOBAL_DIRECTIVES:-}
+            - CADDY_EXTRA_SITE_DIRECTIVES=${CADDY_EXTRA_SITE_DIRECTIVES:-}
         develop:
             watch: # will reload caddy when changing Caddyfile in the host system
                 - path: "./web/Caddyfile"

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
         volumes:
             - "caddy_data:/srv/.local/share/caddy/"
         environment:
-            - SITES=${SITES:-localhost}
+            - DOMAINS=${DOMAINS:-localhost}
             - CADDY_EXTRA_GLOBAL_DIRECTIVES=${CADDY_EXTRA_GLOBAL_DIRECTIVES:-}
             - CADDY_EXTRA_SITE_DIRECTIVES=${CADDY_EXTRA_SITE_DIRECTIVES:-}
         develop:

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,7 @@ services:
             - "caddy_data:/srv/.local/share/caddy/"
         environment:
             - SITES=${SITES:-http://localhost}
+            - CADDY_EXTRA_GLOBAL_DIRECTIVES=${CADDY_EXTRA_GLOBAL_DIRECTIVES:-}
         develop:
             watch: # will reload caddy when changing Caddyfile in the host system
                 - path: "./web/Caddyfile"

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
         volumes:
             - "caddy_data:/srv/.local/share/caddy/"
         environment:
-            - DOMAINS=${DOMAINS:-http://localhost}
+            - SITES=${SITES:-http://localhost}
         develop:
             watch: # will reload caddy when changing Caddyfile in the host system
                 - path: "./web/Caddyfile"

--- a/config.env
+++ b/config.env
@@ -4,7 +4,11 @@ DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
 DEV_SITES=http://localhost
 # Can also be multiple domains:
-# DEV_SITES=http://localhost http://172.31.45.75
+# DEV_SITES=http://localhost http://ip6-localhost
+
+# IMPORTANT: For the `dev-tls` make target, you can't put IP literals in the SITES variable, unless
+#            you only put exactly one and also make it https, in which case you need to set default_sni
+#            in the Caddyfile, see https://github.com/caddyserver/caddy/issues/6344
 
 # When running make prod, the variables HTTP_PORT, HTTPS_PORT, SITES
 # will be set depending on these variables:

--- a/config.env
+++ b/config.env
@@ -1,19 +1,19 @@
 # Important: Never put quotes anywhere: https://github.com/docker/cli/issues/3630
 
-# When running make dev, the variables HTTP_PORT, HTTPS_PORT, SITES
+# When running make dev, the variables HTTP_PORT, HTTPS_PORT, DOMAINS
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
-DEV_SITES=localhost
+DEV_DOMAINS=localhost
 # Can also be multiple domains:
-# DEV_SITES=localhost ip6-localhost
+# DEV_DOMAINS=localhost ip6-localhost
 # IMPORTANT: If you want https to work with IP literals, you need to set default_sni: https://github.com/caddyserver/caddy/issues/6344
 
-# When running make prod, the variables HTTP_PORT, HTTPS_PORT, SITES
+# When running make prod, the variables HTTP_PORT, HTTPS_PORT, DOMAINS
 # will be set depending on these variables:
 PROD_HTTP_PORT=80
 PROD_HTTPS_PORT=443
-PROD_SITES=ft-transcendence.app
+PROD_DOMAINS=ft-transcendence.app
 
 BACKEND_PORT=3000
 

--- a/config.env
+++ b/config.env
@@ -1,3 +1,5 @@
+# Important: Never put quotes anywhere: https://github.com/docker/cli/issues/3630
+
 # When running make dev, the variables HTTP_PORT, HTTPS_PORT, SITES
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080

--- a/config.env
+++ b/config.env
@@ -1,16 +1,16 @@
-# When running make dev, the variables HTTP_PORT, HTTPS_PORT, DOMAINS
+# When running make dev, the variables HTTP_PORT, HTTPS_PORT, SITES
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
-DEV_DOMAINS=http://localhost
+DEV_SITES=http://localhost
 # Can also be multiple domains:
-# DEV_DOMAINS=http://localhost http://172.31.45.75
+# DEV_SITES=http://localhost http://172.31.45.75
 
-# When running make prod, the variables HTTP_PORT, HTTPS_PORT, DOMAINS
+# When running make prod, the variables HTTP_PORT, HTTPS_PORT, SITES
 # will be set depending on these variables:
 PROD_HTTP_PORT=80
 PROD_HTTPS_PORT=443
-PROD_DOMAINS=https://ft-transcendence.app
+PROD_SITES=https://ft-transcendence.app
 
 BACKEND_PORT=3000
 

--- a/config.env
+++ b/config.env
@@ -4,19 +4,16 @@
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
-DEV_SITES=http://localhost
+DEV_SITES=localhost
 # Can also be multiple domains:
-# DEV_SITES=http://localhost http://ip6-localhost
-
-# IMPORTANT: For the `dev-tls` make target, you can't put IP literals in the SITES variable, unless
-#            you only put exactly one and also make it https, in which case you need to set default_sni
-#            in the Caddyfile, see https://github.com/caddyserver/caddy/issues/6344
+# DEV_SITES=localhost ip6-localhost
+# IMPORTANT: If you want https to work with IP literals, you need to set default_sni: https://github.com/caddyserver/caddy/issues/6344
 
 # When running make prod, the variables HTTP_PORT, HTTPS_PORT, SITES
 # will be set depending on these variables:
 PROD_HTTP_PORT=80
 PROD_HTTPS_PORT=443
-PROD_SITES=https://ft-transcendence.app
+PROD_SITES=ft-transcendence.app
 
 BACKEND_PORT=3000
 

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -1,6 +1,4 @@
 {
-	acme_ca https://acme.zerossl.com/v2/DV90
-	email nobody@nobody.org
 	skip_install_trust # caddy is running as non-root, therefore CA trust installation won't work (and isn't needed anyway inside the container)
 	http_port 8080
 	https_port 8443

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -18,7 +18,7 @@
 	}
 }
 
-{$SITES:localhost} {
+{$DOMAINS:localhost} {
 	{$CADDY_EXTRA_SITE_DIRECTIVES}
 	log
 	handle {

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -19,7 +19,7 @@
 	}
 }
 
-{$DOMAINS:http://localhost} {
+{$SITES:http://localhost} {
 	handle {
 		import waf
 		root * /srv

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -21,6 +21,7 @@
 }
 
 {$SITES:http://localhost} {
+	{$CADDY_EXTRA_SITE_DIRECTIVES}
 	handle {
 		import waf
 		root * /srv

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -18,9 +18,9 @@
 	}
 }
 
-{$SITES:http://localhost} {
-	log
+{$SITES:localhost} {
 	{$CADDY_EXTRA_SITE_DIRECTIVES}
+	log
 	handle {
 		import waf
 		root * /srv

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -19,6 +19,7 @@
 }
 
 {$SITES:http://localhost} {
+	log
 	{$CADDY_EXTRA_SITE_DIRECTIVES}
 	handle {
 		import waf

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -5,6 +5,7 @@
 	http_port 8080
 	https_port 8443
 	order coraza_waf first
+	{$CADDY_EXTRA_GLOBAL_DIRECTIVES}
 }
 
 (waf) {


### PR DESCRIPTION
- Add a bit of shell trickery and another Makefile target so that caddy listens on http and https and doesn't autoredirect http to https (which it does by default)
- Some formatting things