### PR TITLE
Support old compose version & some cleanup

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,7 +12,7 @@ die () {
 format_staged () (
 	[ "$#" -lt 1 ] && die "format_staged function expects at least 1 extension as an argument"
 	command -v npx 1>/dev/null 2>&1 || die "Please install npx to run pre-commit hooks"
-	npx prettier -v 1>/dev/null 2>&1 || die "Please install prettier through npx to run pre-commit hooks"
+	npx prettier --version 1>/dev/null 2>&1 || die "Please install prettier through npx to run pre-commit hooks"
 
 	IFS='|'
 	if git diff --name-only --cached --diff-filter=d | \

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -3,7 +3,7 @@ name: Deploy to prod by SSH'ing to a host and running make prod
 on:
     push:
         branches:
-            - main # should be ${{ secrets.PRODUCTION_BRANCH }}
+            - main # should be ${{ secrets.PRODUCTION_BRANCH }}, but workflows apparently don't allow it here
 
 jobs:
     # Expects the host to have this

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -29,10 +29,10 @@ jobs:
 
             - name: Write SSH keys
               run: |
-                  install --mode=600 -D /dev/null ~/.ssh/id_ed25519
+                  install -m=600 -D /dev/null ~/.ssh/id_ed25519
                   printf '%s' '${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}' > ~/.ssh/id_ed25519
                   host='${{ secrets.PRODUCTION_SSH_HOST }}'
-                  hosts="$(dig +short "$host" | grep --invert-match '\.$' | sed --null-data 's|\n|,|g')$host"
+                  hosts="$(dig +short "$host" | grep -v '\.$' | sed -z 's|\n|,|g')$host"
                   ssh-keyscan -H -p ${{ secrets.PRODUCTION_SSH_PORT }} "$hosts" > ~/.ssh/known_hosts
 
             - name: Connect, Pull, Make
@@ -56,4 +56,4 @@ jobs:
                      make prod"
 
             - name: Cleanup
-              run: rm --recursive --force ~/.ssh
+              run: rm -rf ~/.ssh

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ define wait-progress
 	sleep 1
 endef
 
-.PHONY: dev
+.PHONY: dev-old-compose
 dev-old-compose: check-env clean-app-volumes
 	@$(call dev-env,build)
 	@$(call dev-env,up --remove-orphans --detach $(ARGS))

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,54 @@ check-env:
 	}
 
 .PHONY: dev
+dev-old-compose: check-env clean-app-volumes
+	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
+	[ -n "$(DEV_HTTPS_PORT)" ] &&  \
+	[ -n "$(DEV_DOMAINS)" ]    &&  \
+	HTTP_PORT="$(DEV_HTTP_PORT)"   \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	DOMAINS="$(DEV_DOMAINS)"       \
+	NODE_ENV="development"         \
+	WATCH="1"                      \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
+	$(DC) build
+	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
+	[ -n "$(DEV_HTTPS_PORT)" ] &&  \
+	[ -n "$(DEV_DOMAINS)" ]    &&  \
+	HTTP_PORT="$(DEV_HTTP_PORT)"   \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	DOMAINS="$(DEV_DOMAINS)"       \
+	NODE_ENV="development"         \
+	WATCH="1"                      \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
+	$(DC) up
+	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
+	[ -n "$(DEV_HTTPS_PORT)" ] &&  \
+	[ -n "$(DEV_DOMAINS)" ]    &&  \
+	HTTP_PORT="$(DEV_HTTP_PORT)"   \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	DOMAINS="$(DEV_DOMAINS)"       \
+	NODE_ENV="development"         \
+	WATCH="1"                      \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
+	$(DC) logs -f &
+	@sleep .5
+	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
+	[ -n "$(DEV_HTTPS_PORT)" ] &&  \
+	[ -n "$(DEV_DOMAINS)" ]    &&  \
+	HTTP_PORT="$(DEV_HTTP_PORT)"   \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
+	DOMAINS="$(DEV_DOMAINS)"       \
+	NODE_ENV="development"         \
+	WATCH="1"                      \
+	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
+	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
+	$(DC) watch
+
+.PHONY: dev
 dev: check-env clean-app-volumes
 	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
 	[ -n "$(DEV_HTTPS_PORT)" ] &&  \

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,9 @@ endef
 
 .PHONY: dev-old-compose
 dev-old-compose: check-env clean-app-volumes
+	@[ -n "$(ARGS)" ] && { printf '\033[31m%s\033[m\n' "ARGS argument not supported for dev-old-compose target (because of --detach option)"; exit 1; }
 	@$(call dev-env,build)
-	@$(call dev-env,up --remove-orphans --detach $(ARGS))
+	@$(call dev-env,up --remove-orphans --detach)
 	@$(call dev-env,logs --follow &)
 	@$(call wait-progress,5)
 	@$(call wait-progress,4)

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ deepclean: fclean
 		"and consider 'make clean' instead.\n"                                  \
 		"Press ENTER to continue anyway..." && read c
 	$(MAKE) clean
-	$(D) ps --quiet --all | xargs -r $(D) rm --force # non-graceful shutdown because wdgaf
+	$(D) ps --quiet --all | xargs -r $(D) rm -f # non-graceful shutdown because wdgaf
 	$(D) system prune --all --volumes --force        # dangerous
 
 .PHONY: re

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -14,10 +14,10 @@ RUN adduser -h /frontend/ -S caddy -G caddy
 
 FROM alpine:3.21.3
 
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
-COPY                ./Caddyfile /etc/caddy/Caddyfile
+COPY --from=builder      /usr/bin/caddy /usr/bin/caddy
+COPY --from=builder      /etc/passwd /etc/passwd
+COPY --from=builder      /etc/group /etc/group
+COPY --chown=caddy:caddy ./Caddyfile /etc/caddy/Caddyfile
 
 RUN rm -rf /frontend/ && mkdir -p /frontend/.local/share/caddy/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,14 @@
-# Build Stage: TypeScript + Webpack
 FROM node:23.9.0-alpine3.21
 
 WORKDIR /frontend/
 
 VOLUME /frontend/dist/
 
-# Install dependencies and build
 COPY ./package*.json ./
 
 RUN npm clean-install
 
 COPY ./ ./
-
-#TODO: @timo: remove later, not really needed anymore
-#RUN rm -rf ./dist/ && mkdir -p ./dist/ && \
-#	ln -sf /frontend/src/public/index.html ./dist/index.html && \
-#	ln -sf /frontend/src/public/assets/    ./dist/assets
 
 RUN npm run build
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
     "scripts": {
         "build": "tsc --noEmit && npm run build:css && npm run build:js",
         "build:dev": "tsc --noEmit && concurrently \"npm run build:css:dev\" \"npm run build:js:dev\" \"npm run reload\"",
-        "build:css": "npx tailwindcss -i ./src/styles/styles.css -o ./dist/output.css --minify",
-        "build:css:dev": "npx tailwindcss -i ./src/styles/styles.css -o ./dist/output.css --watch",
+        "build:css": "npx tailwindcss --input ./src/styles/styles.css --output ./dist/output.css --minify",
+        "build:css:dev": "npx tailwindcss --input ./src/styles/styles.css --output ./dist/output.css --watch",
         "build:js": "node esbuild.config.js",
         "build:js:dev": "node esbuild.config.js --watch",
         "reload": "node reload-server.js"


### PR DESCRIPTION
- If your `docker compose version` is below `2.25.0`, running `make`/`make dev`/`make re` will not work. Instead, you will have to run `make dev-old-compose` or `make clean && make dev-old-compose` if you want to replicate `make re`
- Also removed some comments and normalized the style (POSIX utils -> short options, non-POSIX utils -> long options)