### PR TITLE
Replace space with tab in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ cleanvault: clean
 fclean: clean cleandb cleanvault
 	$(RM) -r ./backend/node_modules/ backend/dist/ backend/.tap/
 	$(RM) -r ./frontend/node_modules/ frontend/dist/
-  $(RM) -r cli/node_modules/
+	$(RM) -r ./cli/node_modules/
 	$(RM) -r $(VAULT_TOKEN_EXCHANGE_FILES)
 
 .PHONY: deepclean


### PR DESCRIPTION
Just a small fix that replaces some spaces with tabs (otherwise, `make` complains :'D)