### PR TITLE
Feature/hotreload support vault

### DIFF
--- a/backend/src/core/config/config.plugin.ts
+++ b/backend/src/core/config/config.plugin.ts
@@ -27,7 +27,9 @@ const readVaultOnce = async (path: string) => {
 			throw new Error(`Request to vault API FAILED:\n${e}`);
 		});
 
-	fs.writeFileSync("/run/secrets/backend_vault_token", ""); // clear, since not needed anymore, but token-max-use should be set to 1 anyways
+	if (process.env.NODE_ENV === "production") {
+		fs.writeFileSync("/run/secrets/backend_vault_token", "");
+	}
 
 	return promise;
 }

--- a/backend/src/core/config/config.plugin.ts
+++ b/backend/src/core/config/config.plugin.ts
@@ -9,11 +9,12 @@ const readVaultOnce = async (path: string) => {
 	const vaultToken = fs.readFileSync("/run/secrets/backend_vault_token", "utf8");
 
 	const promise = fetch(`http://vault:8200/v1/${path}`, {headers:{"X-Vault-Token": vaultToken}})
-		.then((resp) => {
+		.then(async (resp) => {
+			const respText = await resp.text();
 			if (!resp.ok) {
-				throw new Error(`Request to vault API was NOT OK:\n${resp.text()}`);
+				throw new Error(`Request to vault API was NOT OK:\n${respText}`);
 			}
-			return resp.text();
+			return respText;
 		})
 		.then((text) => {
 			try {

--- a/compose.yaml
+++ b/compose.yaml
@@ -184,6 +184,7 @@ services:
             - "vault_secret:/vault/secret/"
             - "./.secrets/backend_vault_token:/run/secrets/backend_vault_token"
         environment:
+            <<: *watch-common
             LOGLEVEL: "debug"
             SAVE_UNSEAL_KEYS: "1"
             SAVE_ROOT_TOKEN: "1"


### PR DESCRIPTION
Adds hotreload support while also using vault, by creating ephemeral tokens ONLY in production. Also fixes a small logging issue in backend because I forgot to approve copilot's suggestions in the last PR.