### PR TITLE
Refactor/cleanup volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ cleandb: clean
 .PHONY: cleanvault
 cleanvault: clean
 	$(D) volume rm --force ft-transcendence_vault
+	$(D) volume rm --force ft-transcendence_vault-secrets
 
 .PHONY: fclean
 fclean: clean cleandb cleanvault

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ down:
 .PHONY: clean-app-volumes
 clean-app-volumes: down
 	$(D) volume rm --force ft-transcendence_frontend
+	$(D) volume rm --force ft-transcendence_vault-logs
+	$(D) volume rm --force ft-transcendence_elasticsearch-data
 
 .PHONY: clean
 clean:

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /frontend/
 EXPOSE 8080
 EXPOSE 8443
 
-VOLUME ["/frontend/.local/share/caddy/", "/frontend/dist/", "/frontend/src/public/"]
+VOLUME ["/frontend/.local/share/caddy/", "/frontend/dist/"]
 
 USER caddy
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -182,6 +182,7 @@ services:
         volumes:
             - "vault:/vault/file/"
             - "vault-secret:/vault/secret/"
+            - "vault-logs:/vault/logs/"
             - "./.secrets/backend_vault_token:/run/secrets/backend_vault_token"
         environment:
             LOGLEVEL: "debug"
@@ -212,6 +213,7 @@ services:
 volumes:
     vault:
     vault-secret:
+    vault-logs:
     caddy-data:
     drizzle:
     frontend:

--- a/compose.yaml
+++ b/compose.yaml
@@ -110,7 +110,7 @@ services:
             discovery.type: "single-node"
             xpack.security.enabled: "false"
         volumes:
-            - "elasticsearch_data:/usr/share/elasticsearch/data/"
+            - "elasticsearch-data:/usr/share/elasticsearch/data/"
         ports:
             - "9200:9200"
         networks:
@@ -217,7 +217,7 @@ volumes:
     caddy-data:
     drizzle:
     frontend:
-    elasticsearch_data:
+    elasticsearch-data:
 
 networks:
     ft-transcendence-net:

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
             ft-transcendence-net:
                 ipv4_address: &caddy-ip 10.42.42.1
         volumes:
-            - "caddy_data:/frontend/.local/share/caddy/"
+            - "caddy-data:/frontend/.local/share/caddy/"
             - "frontend:/frontend/dist/:ro"
         environment:
             <<: *env-caddy-backend
@@ -181,7 +181,7 @@ services:
             - IPC_LOCK
         volumes:
             - "vault:/vault/file/"
-            - "vault_secret:/vault/secret/"
+            - "vault-secret:/vault/secret/"
             - "./.secrets/backend_vault_token:/run/secrets/backend_vault_token"
         environment:
             LOGLEVEL: "debug"
@@ -211,8 +211,8 @@ services:
 
 volumes:
     vault:
-    vault_secret:
-    caddy_data:
+    vault-secret:
+    caddy-data:
     drizzle:
     frontend:
     elasticsearch_data:


### PR DESCRIPTION
- Caddy had an unused VOLUME (declared *only* in the Dockerfile -> therefore anonymous) -> removed it
- The hashicorp/vault image specifies a /vault/logs volume, but we don't specify one in compose.yaml. I added it there
- Also some style changes in compose.yaml