### PR TITLE
Autoprune when deploy and allow http (8080) only on localhost

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -40,19 +40,19 @@ jobs:
               # Also, git stash --include-untracked will leave stuff that is in .gitignore, most importantly, .env
               run: |
                   ssh \
-                    -o IdentitiesOnly=yes                                                                             \
-                    -i ~/.ssh/id_ed25519                                                                              \
-                    -o UserKnownHostsFile=~/.ssh/known_hosts                                                          \
-                    -T                                                                                                \
-                    -p ${{ secrets.PRODUCTION_SSH_PORT }}                                                             \
-                    ${{ secrets.PRODUCTION_SSH_USER }}@${{ secrets.PRODUCTION_SSH_HOST }}                             \
-                    ": GH_ACTIONS_PRODUCTION ;                                                                        \
-                     set -Eeuxo pipefail ;                                                                            \
-                     cd ${{ secrets.PRODUCTION_WORK_DIR }} ;                                                          \
-                     git stash --include-untracked || : ; : 'git stash may fail (if it does, prolly docker related' ; \
-                     git checkout --force ${{ secrets.PRODUCTION_BRANCH }} ;                                          \
-                     git pull --rebase --force ${{ secrets.REMOTE_NAME }} ${{ secrets.PRODUCTION_BRANCH }} ;          \
-                     make down ;                                                                                      \
+                    -o IdentitiesOnly=yes                                                                                        \
+                    -i ~/.ssh/id_ed25519                                                                                         \
+                    -o UserKnownHostsFile=~/.ssh/known_hosts                                                                     \
+                    -T                                                                                                           \
+                    -p ${{ secrets.PRODUCTION_SSH_PORT }}                                                                        \
+                    ${{ secrets.PRODUCTION_SSH_USER }}@${{ secrets.PRODUCTION_SSH_HOST }}                                        \
+                    ": GH_ACTIONS_PRODUCTION ;                                                                                   \
+                     set -Eeuxo pipefail ;                                                                                       \
+                     cd ${{ secrets.PRODUCTION_WORK_DIR }} ;                                                                     \
+                     git stash --include-untracked || : ; : 'git stash may fail (if it does, prolly docker related' ;            \
+                     git checkout --force ${{ secrets.PRODUCTION_BRANCH }} ;                                                     \
+                     git pull --rebase --force --prune --autostash ${{ secrets.REMOTE_NAME }} ${{ secrets.PRODUCTION_BRANCH }} ; \
+                     make down ;                                                                                                 \
                      make prod"
 
             - name: Cleanup

--- a/Makefile.aux
+++ b/Makefile.aux
@@ -15,29 +15,36 @@ check-env:
 		cp .env.example .env; \
 	}
 
+# Kind of ugly we have to do HTTP_DOMAINS and HTTPS_DOMAINS here, but inside Caddyfile it's kinda impossible
+# to do conditional logic (prod/dev) and text transformation (addprefix)
 define dev-env
-	[ -n "$(DEV_HTTP_PORT)" ]  &&  \
-	[ -n "$(DEV_HTTPS_PORT)" ] &&  \
-	[ -n "$(DEV_DOMAINS)" ]    &&  \
-	HTTP_PORT="$(DEV_HTTP_PORT)"   \
-	HTTPS_PORT="$(DEV_HTTPS_PORT)" \
-	DOMAINS="$(DEV_DOMAINS)"       \
-	NODE_ENV="development"         \
-	WATCH="1"                      \
+	[ -n "$(DEV_HTTP_PORT)" ]  &&                        \
+	[ -n "$(DEV_HTTPS_PORT)" ] &&                        \
+	[ -n "$(DEV_DOMAINS)" ]    &&                        \
+	HTTP_PORT="$(DEV_HTTP_PORT)"                         \
+	HTTPS_PORT="$(DEV_HTTPS_PORT)"                       \
+	DOMAINS="$(DEV_DOMAINS)"                             \
+	HTTP_DOMAINS="$(addprefix http://,$(DEV_DOMAINS))"   \
+	HTTPS_DOMAINS="$(addprefix https://,$(DEV_DOMAINS))" \
+	NODE_ENV="development"                               \
+	WATCH="1"                                            \
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
 	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(DEV_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
 	$(DC) $(1)
 endef
 
+# Empty HTTP_DOMAINS for prod, since we want auto redirection to https
 define prod-env
-	[ -n "$(PROD_HTTP_PORT)" ]  &&  \
-	[ -n "$(PROD_HTTPS_PORT)" ] &&  \
-	[ -n "$(PROD_DOMAINS)" ]    &&  \
-	HTTP_PORT="$(PROD_HTTP_PORT)"   \
-	HTTPS_PORT="$(PROD_HTTPS_PORT)" \
-	DOMAINS="$(PROD_DOMAINS)"       \
-	NODE_ENV="production"           \
-	WATCH="0"                       \
+	[ -n "$(PROD_HTTP_PORT)" ]  &&                        \
+	[ -n "$(PROD_HTTPS_PORT)" ] &&                        \
+	[ -n "$(PROD_DOMAINS)" ]    &&                        \
+	HTTP_PORT="$(PROD_HTTP_PORT)"                         \
+	HTTPS_PORT="$(PROD_HTTPS_PORT)"                       \
+	DOMAINS="$(PROD_DOMAINS)"                             \
+	HTTP_DOMAINS=""                                       \
+	HTTPS_DOMAINS="$(addprefix https://,$(PROD_DOMAINS))" \
+	NODE_ENV="production"                                 \
+	WATCH="0"                                             \
 	CADDY_EXTRA_GLOBAL_DIRECTIVES="$$(printf %b "$(PROD_CADDY_EXTRA_GLOBAL_DIRECTIVES)")" \
 	CADDY_EXTRA_SITE_DIRECTIVES="$$(printf %b "$(PROD_CADDY_EXTRA_SITE_DIRECTIVES)")"     \
 	$(DC) $(1)

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,7 +18,10 @@
 	}
 }
 
-localhost:8080 {$DOMAINS:localhost} {
+# Setting HTTP_DOMAINS? to null (empty string) will NOT trigger default replacement!
+# Unset the the variable instead if you want the default value.
+# https://caddyserver.com/docs/caddyfile/concepts#environment-variables
+{$HTTP_DOMAINS:http://localhost} {$HTTPS_DOMAINS:https://localhost} {
 	{$CADDY_EXTRA_SITE_DIRECTIVES}
 	log
 	handle {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,7 +18,7 @@
 	}
 }
 
-:8080 {$DOMAINS:localhost} {
+localhost:8080 {$DOMAINS:localhost} {
 	{$CADDY_EXTRA_SITE_DIRECTIVES}
 	log
 	handle {

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,6 +29,8 @@ services:
             - "frontend:/frontend/dist/:ro"
         environment:
             <<: *env-caddy-backend
+            HTTP_DOMAINS: "${HTTP_DOMAINS:-http://localhost}"
+            HTTPS_DOMAINS: "${HTTPS_DOMAINS:-https://localhost}"
             CADDY_EXTRA_GLOBAL_DIRECTIVES: "${CADDY_EXTRA_GLOBAL_DIRECTIVES:-}"
             CADDY_EXTRA_SITE_DIRECTIVES: "${CADDY_EXTRA_SITE_DIRECTIVES:-}"
         depends_on:

--- a/config.env
+++ b/config.env
@@ -1,20 +1,27 @@
 # Important: Never put quotes anywhere: https://github.com/docker/cli/issues/3630
 # Although, in compose it should actually work: https://docs.docker.com/reference/compose-file/services/#env_file-format
 
-# When running 'make dev', the variables HTTP_PORT, HTTPS_PORT, DOMAINS
+# When running 'make dev', the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
 DEV_DOMAINS=localhost ft-transcendence.app
 # Can also be multiple domains:
 # DEV_DOMAINS=localhost ip6-localhost
+#
 # IMPORTANT: If you want https to work with IP literals, you need to set the global
 # default_sni directive in Caddyfile: https://github.com/caddyserver/caddy/issues/6344
+#
+# To access a local domains via https, you may have to disable HSTS by typing
+# 'thisisunsafe' while being on the warning page: https://stackoverflow.com/a/49130998
+#
+# Note that for .app domains, disabling HSTS and visiting them via http is
+# impossible: https://stackoverflow.com/a/51677379
 DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES=auto_https disable_redirects
 DEV_CADDY_EXTRA_SITE_DIRECTIVES=tls internal
 # The previous 2 environment variables are passed through printf %b, allowing for newlines using \n syntax
 
-# When running 'make prod', the variables HTTP_PORT, HTTPS_PORT, DOMAINS
+# When running 'make prod', the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
 # will be set depending on these variables:
 PROD_HTTP_PORT=80
 PROD_HTTPS_PORT=443

--- a/config.env
+++ b/config.env
@@ -5,7 +5,7 @@
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
-DEV_DOMAINS=localhost
+DEV_DOMAINS=localhost ft-transcendence.app
 # Can also be multiple domains:
 # DEV_DOMAINS=localhost ip6-localhost
 # IMPORTANT: If you want https to work with IP literals, you need to set the global


### PR DESCRIPTION
Also, properly support multiple domains for dev mode (i.e. when you add them in /etc/hosts). Note that this doesn't work for .app domains, see comment in config.env.