### PR TITLE
Remove totpSecret from toPersonalUser function

### DIFF
--- a/backend/src/modules/user/user.helpers.ts
+++ b/backend/src/modules/user/user.helpers.ts
@@ -5,7 +5,7 @@ import { User } from "./user.types.ts";
 /** Remove sensitive fields from user before sending response to themselves. */
 export const toPersonalUser = (user: User): Omit<User, "passwordHash" | "totpSecret"> => {
     const { passwordHash, totpSecret, ...personalUser } = user;
-    return personalUser;
+    return personalUser; // TODO: Maybe add type "PersonalUser"
 };
 
 /** Remove sensitive fields from user before sending response to public. */

--- a/backend/src/modules/user/user.helpers.ts
+++ b/backend/src/modules/user/user.helpers.ts
@@ -3,8 +3,8 @@ import { PublicUser } from "@darrenkuro/pong-core";
 import { User } from "./user.types.ts";
 
 /** Remove sensitive fields from user before sending response to themselves. */
-export const toPersonalUser = (user: User): Omit<User, "passwordHash"> => {
-    const { passwordHash, ...personalUser } = user;
+export const toPersonalUser = (user: User): Omit<User, "passwordHash" | "totpSecret"> => {
+    const { passwordHash, totpSecret, ...personalUser } = user;
     return personalUser;
 };
 


### PR DESCRIPTION
The secret is provided during the provisioning process, it should never be needed again. Although toPersonalUser and toPublicUser are identical now, we should keep the function there in case there's "personal" stuff later down the line that needs to be remove in the toPublicUser function but kept inside the toPersonalUser function. Didn't add a PersonalUser type yet, didn't seem so important to do so.