### PR TITLE
Fix quote checker script to work on macOS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,15 +10,16 @@ die () {
 
 # subshell to not clobber IFS
 format_staged () (
+	PRETTIER_BIN="backend/node_modules/.bin/prettier"
+
 	[ "$#" -lt 1 ] && die "format_staged function expects at least 1 extension as an argument"
-	command -v npx 1>/dev/null 2>&1 || die "Please install npx to run pre-commit hooks"
-	npx prettier --version 1>/dev/null 2>&1 || die "Please install prettier through npx to run pre-commit hooks"
+	command -v $PRETTIER_BIN 1>/dev/null 2>&1 || die "Please install prettier to run pre-commit hooks"
 
 	IFS='|'
 	if git diff --name-only --cached --diff-filter=d | \
 		grep -E "\.($*)\$"                        | \
 		tr '\n' '\0'                              | \
-		xargs -r0 npx prettier --list-different 1>/dev/null; then
+		xargs -r0 $PRETTIER_BIN --list-different 1>/dev/null; then
 		all_good=1
 	else
 		all_good=0
@@ -27,7 +28,7 @@ format_staged () (
 	git diff --name-only --cached --diff-filter=d | \
 		grep -E "\.($*)\$"                        | \
 		tr '\n' '\0'                              | \
-		xargs -r0 npx prettier --write
+		xargs -r0 $PRETTIER_BIN --write
 
 	if [ ! "$all_good" = "1" ]; then
 		printf '\033[33m%s\033[m\n' "Warning: Not commiting since some files were formatted with prettier"

--- a/config.env
+++ b/config.env
@@ -1,7 +1,7 @@
 # Important: Never put quotes anywhere: https://github.com/docker/cli/issues/3630
 # Although, in compose it should actually work: https://docs.docker.com/reference/compose-file/services/#env_file-format
 
-# When running 'make dev', the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
+# When running "make dev", the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
 # will be set depending on these variables:
 DEV_HTTP_PORT=8080
 DEV_HTTPS_PORT=8443
@@ -13,7 +13,7 @@ DEV_DOMAINS=localhost ft-transcendence.app
 # default_sni directive in Caddyfile: https://github.com/caddyserver/caddy/issues/6344
 #
 # To access a local domains via https, you may have to disable HSTS by typing
-# 'thisisunsafe' while being on the warning page: https://stackoverflow.com/a/49130998
+# "thisisunsafe" while being on the warning page: https://stackoverflow.com/a/49130998
 #
 # Note that for .app domains, disabling HSTS and visiting them via http is
 # impossible: https://stackoverflow.com/a/51677379
@@ -21,7 +21,7 @@ DEV_CADDY_EXTRA_GLOBAL_DIRECTIVES=auto_https disable_redirects
 DEV_CADDY_EXTRA_SITE_DIRECTIVES=tls internal
 # The previous 2 environment variables are passed through printf %b, allowing for newlines using \n syntax
 
-# When running 'make prod', the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
+# When running "make prod", the variables HTTP_PORT, HTTPS_PORT, DOMAINS, ...
 # will be set depending on these variables:
 PROD_HTTP_PORT=80
 PROD_HTTPS_PORT=443

--- a/script/find_quotes
+++ b/script/find_quotes
@@ -50,8 +50,11 @@ find_quotes () {
 			die 'First argument must be one of "dquote", "squote", "backtick", "roff_squote", or "roff_dquote" not "'"$1"'"' ;;
 	esac
 
+	OLDIFS=$IFS
+	IFS="$(printf '\n.')"
+	IFS=${IFS%.}
 	grep \
-		--exclude-from=script/quote_search_exclusions \
+		$(sed 's/^/--exclude=/' script/quote_search_exclusions) \
 		--exclude-dir=node_modules   \
 		--exclude-dir=.git           \
 		--binary-files=without-match \
@@ -68,9 +71,12 @@ find_quotes () {
 			--line-regexp \
 			--fixed-strings |
 			grep_for_quotes "$quote_type"
+	ret=$?
+	IFS=$OLDIFS
+	return $ret
 }
 
-main () (
+main () {
 	minus_n=true
 	option_parsing=true
 	args=
@@ -93,14 +99,16 @@ main () (
 
 	[ -n "$args" ] || die "Expected at least one quote type"
 
+	OLDIFS=$IFS
 	IFS=,
 	found_something=1 # 1==false
 	for quote_type in $args; do
+		IFS=$OLDIFS
 		if find_quotes "$minus_n" "$quote_type"; then
 			found_something=0
 		fi
 	done
 	exit "$found_something"
-)
+}
 
 main "$@"

--- a/script/find_quotes
+++ b/script/find_quotes
@@ -59,7 +59,7 @@ find_quotes () {
 		--exclude-dir=.git           \
 		--binary-files=without-match \
 		--fixed-strings              \
-		--dereference-recursive      \
+		--recursive                  \
 		$first_grep_extra_args       \
 		--regexp '#'  \
 		--regexp '//' \


### PR DESCRIPTION
Used IFS and sed to create a command line with all the exclusions. Drop in replacement for --exclude-from. Has its limits on linux, sine there's a maximum size the command line can have (https://www.in-ulm.de/~mascheck/various/argmax/), but good enough