### PR TITLE
Change backend healthcheck parameters

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 ENV WATCH=0
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=5 \
+HEALTHCHECK --interval=10s --timeout=2s --start-period=60s --start-interval=1s --retries=3 \
   CMD curl --fail http://localhost:${BACKEND_PORT}/healthcheck
 
 CMD ["sh", "-c", "if [ \"$WATCH\" = \"0\" ]; then npm run build && npm start; else npm run start:dev; fi"]


### PR DESCRIPTION
I think the deployment failure is probably due to backend exhaust retries before logstash start-up finish and gets marked healthy?

Add start period of 60s which seems to be the amount of time logstash will be marked unhealthy if I understood it correctly. And adjusted some other parameters which I think makes sense. Tested locally and worked fine, but server will have a different speed. Hopefully this works?