### PR TITLE
Fix/dont print env

### DIFF
--- a/caddy/entrypoint.sh
+++ b/caddy/entrypoint.sh
@@ -29,10 +29,10 @@ get_all_secrets_as_env_params () {
 
 env_params=$(get_all_secrets_as_env_params)
 
-# Print all secrets for logging
-printf "Environment start\n"
-eval printf '"%s\n"' "$env_params"
-printf "Environment end\n"
+# Print all secrets for logging, should only be done for debugging
+# printf "Environment start\n"
+# eval printf '"%s\n"' "$env_params"
+# printf "Environment end\n"
 
 ### Customization Point 3 ###
 eval exec env -- "$env_params" '"$@"'

--- a/elk/elasticsearch/entrypoint.sh
+++ b/elk/elasticsearch/entrypoint.sh
@@ -41,10 +41,10 @@ get_all_secrets_as_env_params () {
 
 env_params=$(get_all_secrets_as_env_params)
 
-# Print all secrets for logging
-printf "Environment start\n"
-eval printf '"%s\n"' "$env_params"
-printf "Environment end\n"
+# Print all secrets for logging, should only be done for debugging
+# printf "Environment start\n"
+# eval printf '"%s\n"' "$env_params"
+# printf "Environment end\n"
 
 # Truncate file for good measure
 : > "/run/secrets/${service}_vault_token"

--- a/elk/kibana/entrypoint.sh
+++ b/elk/kibana/entrypoint.sh
@@ -38,10 +38,10 @@ get_all_secrets_as_env_params () {
 
 env_params=$(get_all_secrets_as_env_params)
 
-# Print all secrets for logging
-printf "Environment start\n"
-eval printf '"%s\n"' "$env_params"
-printf "Environment end\n"
+# Print all secrets for logging, should only be done for debugging
+# printf "Environment start\n"
+# eval printf '"%s\n"' "$env_params"
+# printf "Environment end\n"
 
 # Truncate file for good measure
 : > "/run/secrets/${service}_vault_token"

--- a/elk/logstash/entrypoint.sh
+++ b/elk/logstash/entrypoint.sh
@@ -41,10 +41,10 @@ get_all_secrets_as_env_params () {
 
 env_params=$(get_all_secrets_as_env_params)
 
-# Print all secrets for logging
-printf "Environment start\n"
-eval printf '"%s\n"' "$env_params"
-printf "Environment end\n"
+# Print all secrets for logging, should only be done for debugging
+# printf "Environment start\n"
+# eval printf '"%s\n"' "$env_params"
+# printf "Environment end\n"
 
 # Truncate file for good measure
 : > "/run/secrets/${service}_vault_token"

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -41,10 +41,10 @@ get_all_secrets_as_env_params () {
 
 env_params=$(get_all_secrets_as_env_params)
 
-# Print all secrets for logging
-printf "Environment start\n"
-eval printf '"%s\n"' "$env_params"
-printf "Environment end\n"
+# Print all secrets for logging, should only be done for debugging
+# printf "Environment start\n"
+# eval printf '"%s\n"' "$env_params"
+# printf "Environment end\n"
 
 # Truncate file for good measure
 : > "/run/secrets/${service}_vault_token"

--- a/script/quote_exceptions
+++ b/script/quote_exceptions
@@ -34,3 +34,9 @@ vault/README.md:    # `env` will exec itself, so that's fine as well.
 vault/README.md:    # which is also why we have extra qoutes around this: '"\$@"'
 ./vault/README.md:    # `env` will exec itself, so that's fine as well.
 ./vault/README.md:    # which is also why we have extra qoutes around this: '"\$@"'
+elk/kibana/entrypoint.sh:# eval printf '"%s\n"' "$env_params"
+elk/elasticsearch/entrypoint.sh:# eval printf '"%s\n"' "$env_params"
+elk/logstash/entrypoint.sh:# eval printf '"%s\n"' "$env_params"
+frontend/entrypoint.sh:# eval printf '"%s\n"' "$env_params"
+vault/README.md:    # eval printf '"%s\\n"' "\$env_params"
+caddy/entrypoint.sh:# eval printf '"%s\n"' "$env_params"

--- a/vault/README.md
+++ b/vault/README.md
@@ -261,10 +261,10 @@ Let's say your service is called `foo`, then the steps would be the following:
 
     env_params=\$(get_all_secrets_as_env_params)
 
-    # Print all secrets for logging
-    printf "Environment start\\n"
-    eval printf '"%s\\n"' "\$env_params"
-    printf "Environment end\\n"
+    # Print all secrets for logging, should only be done for debugging
+    # printf "Environment start\\n"
+    # eval printf '"%s\\n"' "\$env_params"
+    # printf "Environment end\\n"
 
     # Truncate file for good measure
     : > "/run/secrets/\${service}_vault_token"


### PR DESCRIPTION
Requires #182

Printing them was for debugging. I'm not gonna introduce another env var named "LOG_LEVEL" for every single service that uses vault just for the purpose of printing those vars or not. If you want to debug, then you have to comment in those lines manually to see the env