### PR TITLE
Pass through ES_JAVA_OPTS, otherwise elasticsearch uses like 9GB of R…

### DIFF
--- a/elk/elasticsearch/config/startup.sh
+++ b/elk/elasticsearch/config/startup.sh
@@ -32,6 +32,7 @@ run_as_elastic () {
 	# Apparently, su resets PATH no matter if you specify --preserve-environment and or --login or not.
 	# We need to explicity pass the current value of PATH (which includes the elasticsearch bin directory)
 	# down, using bash's fancy quoting mechanism.
+	# The `${*@Q}` thing is just the arguments ($*) properly quoted (@Q). Bash is pretty cool eh?
 	su --command="export PATH=${PATH@Q}; ${*@Q}" \
 		elasticsearch
 }


### PR DESCRIPTION
Haven't you also noticed that the services hog up memory like crazy? It's been like this since the very beginning ELK was introduced lol, because we've been running `su --login` or `su -` all the time, which requires whitelisting of the environment. I changed it so the the environment is not cleared anymore, but that requires manual setting of the PATH environment variable, as you can see in the diff, which is accomplished via bash's "Parameter Transformations"